### PR TITLE
Add IndyPets compatability (ignore independent pets)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,10 @@ base {
 }
 
 repositories {
+	maven {
+		name = "Modrinth"
+		url = "https://api.modrinth.com/maven"
+	}
 }
 
 loom {
@@ -32,6 +36,8 @@ dependencies {
 	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 	modImplementation fabricApi.module("fabric-game-rule-api-v1", project.fabric_version)
+
+	modCompileOnly "maven.modrinth:indypets:${project.indypets}"
 
 	testImplementation "net.fabricmc:fabric-loader-junit:${project.loader_version}"
 	testImplementation "org.junit.jupiter:junit-jupiter:5.10.3"

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,5 +15,6 @@ archives_base_name=proper-pet-tp
 
 # Dependencies
 fabric_version=0.102.1+1.21.1
+indypets=HOjegS8s
 
 modrinth_project=ppetp

--- a/src/main/java/nl/theepicblock/ppetp/PPeTP.java
+++ b/src/main/java/nl/theepicblock/ppetp/PPeTP.java
@@ -3,6 +3,7 @@ package nl.theepicblock.ppetp;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.gamerule.v1.GameRuleFactory;
 import net.fabricmc.fabric.api.gamerule.v1.GameRuleRegistry;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.world.GameRules;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -11,6 +12,8 @@ public class PPeTP implements ModInitializer {
 	public static final String MOD_ID = "proper-pet-tp";
 
 	public static final Logger LOGGER = LoggerFactory.getLogger(MOD_ID);
+
+	public static final boolean IS_INDYPETS_LOADED = FabricLoader.getInstance().isModLoaded("indypets");
 
 	public static final GameRules.Key<GameRules.BooleanRule> SHOULD_TP_CROSS_DIMENSIONAL =
 			GameRuleRegistry.register("petTeleportCrossDimension", GameRules.Category.MOBS, GameRuleFactory.createBooleanRule(false));

--- a/src/main/java/nl/theepicblock/ppetp/PetTeleporter.java
+++ b/src/main/java/nl/theepicblock/ppetp/PetTeleporter.java
@@ -3,6 +3,7 @@ package nl.theepicblock.ppetp;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.passive.TameableEntity;
 import net.minecraft.server.network.ServerPlayerEntity;
+import nl.theepicblock.ppetp.compat.IndyPetsCompat;
 import org.jetbrains.annotations.Nullable;
 
 public class PetTeleporter {
@@ -28,9 +29,15 @@ public class PetTeleporter {
 
         // We can't use the normal getOwner method because the player might've died
         var owner = getOwner(pet);
-        if (owner != null) {
-            teleportToInventory(pet, owner);
+        if (owner == null) {
+            return;
         }
+
+        if (PPeTP.IS_INDYPETS_LOADED && IndyPetsCompat.isIndependent(pet)) {
+            // The pet is just walking around and not following, so ignore it
+            return;
+        }
+        teleportToInventory(pet, owner);
     }
 
     /**

--- a/src/main/java/nl/theepicblock/ppetp/compat/IndyPetsCompat.java
+++ b/src/main/java/nl/theepicblock/ppetp/compat/IndyPetsCompat.java
@@ -1,0 +1,11 @@
+package nl.theepicblock.ppetp.compat;
+
+import com.lizin5ths.indypets.util.IndyPetsUtil;
+import net.minecraft.entity.Entity;
+
+public class IndyPetsCompat {
+
+    public static boolean isIndependent(Entity entity) {
+        return IndyPetsUtil.isActiveIndependent(entity);
+    }
+}


### PR DESCRIPTION
Without these changes pets that are set to be "independent" by the IndyPets mods are being teleported to the owner on unload, but they should not. I added a simple check for independence, if pet is independent it is ignored and would not be teleported.

P.S. I am not sure if i added the IndyPets dependency the right way but it worked for me. 